### PR TITLE
fixes for ex.git.branch

### DIFF
--- a/lua/lualine/components/ex/git/branch.lua
+++ b/lua/lualine/components/ex/git/branch.lua
@@ -76,7 +76,8 @@ function GitBranch:is_enabled()
 end
 
 function GitBranch:update_status()
-    return self.git():get_branch() or ''
+    local branch_name = self.git():get_branch()
+    return branch_name and branch_name:gsub('%%', '%%%%') or ''
 end
 
 return GitBranch

--- a/lua/lualine/ex/annotations.lua
+++ b/lua/lualine/ex/annotations.lua
@@ -5,8 +5,8 @@
 ---@alias StatuslineHighlight string # `%#<HighlightGroup>#`
 
 ---@class Color # Highlight definition map. See :help nvim_set_hl
----@field fg Color
----@field bg Color
+---@field fg RGB
+---@field bg RGB
 
 ---@class HighlightToken # any table identifier received from create_hl or create_component_highlight_group
 ---@field name HighlightGroup

--- a/tests/components/git_branch_spec.lua
+++ b/tests/components/git_branch_spec.lua
@@ -70,6 +70,13 @@ describe('ex.git.branch component', function()
             eq('main', c:update_status())
         end)
 
+        it('should escape % symbols in a name of the current branch', function()
+            local branch = '%branch'
+            git:new_branch(branch)
+            local c = l.init_component(component_name)
+            eq('%' .. branch, c:update_status())
+        end)
+
         it('a rendered component should have the branch name and the icon', function()
             git:checkout('main')
             local rendered_component = l.render_component(component_name)

--- a/tests/ex/git.lua
+++ b/tests/ex/git.lua
@@ -1,3 +1,13 @@
+---This is util to work with git.
+---@class Git
+---@field apply fun(git_root: string) create a new instance of the {Git} to work with git
+---  inside the {git_root}.
+---@field git fun(...) execute git with passed arguments.
+---@field init fun(branch: string) init a new git repo with branch named {branch}.
+---@field checkout fun(branch_name: string) checkout {branch_name}.
+---@field new_branch fun(branch_name) creates a new branch.
+local Git = {}
+
 local log = require('plenary.log').new({
     plugin = 'tests.ex.git',
     use_file = false,
@@ -6,7 +16,6 @@ local log = require('plenary.log').new({
 
 local dev_null = (vim.env.DEBUG or vim.env.DEBUG_PLENARY) and '' or ' &> /dev/null'
 
-local Git = {}
 setmetatable(Git, {
     __call = function(_, git_root)
         local obj = {

--- a/tests/git_provider_spec.lua
+++ b/tests/git_provider_spec.lua
@@ -59,12 +59,30 @@ describe('inside a git worktree', function()
         eq(git_root, p:git_root())
     end)
 
+    it('read_git_branch should return the name of the current git branch', function()
+        local p = GitProvider:new(git_root)
+        eq('main', p:read_git_branch())
+    end)
+
+    it('read_git_branch should return the name of the new git branch', function()
+        local p = GitProvider:new(git_root)
+        -- when:
+        git:new_branch('new_branch')
+        -- then:
+        local head = fs.path(git_root, '.git', 'HEAD')
+        eq(
+            'new_branch',
+            p:read_git_branch(),
+            string.format('Content of the %s:\n%s', head, fs.read(head))
+        )
+    end)
+
     it('get_branch should return the name of the current git branch', function()
         local p = GitProvider:new(git_root)
         eq('main', p:get_branch())
     end)
 
-    -- FIXME: find a reason why this test fails
+    -- FIXME: find a reason why this test fails. It looks like event about HEAD changes is loosing.
     t.ignore_it('get_branch should return the name of the new git branch', function()
         local p = GitProvider:new(git_root)
         eq('main', p:get_branch())


### PR DESCRIPTION
 - read from HEAD any non-space characters as a git branch name
 - escape % in git branch name