### PR TITLE
feat: ex.relative_filename

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,12 +31,18 @@ You can run separate test file or tests from a subdirectory passing 'only' param
 > make test only=components/git_branch_spec.lua
 or
 > make test only=components
-\nTo turn on debug logs use 'DEBUG_PLENARY' with minimal log level or `true`:
+
+To turn on debug logs use 'DEBUG_PLENARY' with minimal log level or `true`:
 > make test DEBUG_PLENARY=true
-\nTo try the specific component in demo you can specify its name:
-> make demo component=ex.lsp.all
-\nYou can pass any argument to the demo task. For example,it can be a path to file which should be opened:
-> make demo path=<path to file>
+
+To try the specific component in demo you can specify its name:
+> make demo component=ex.cwd
+
+You can pass a path to file which should be opened in demo:
+> make demo component=ex.cwd path=<path to file>
+
+Also, you can pass custom options to the demo component as a json:
+> make demo component=ex.cwd component_opts='{ "depth": 1 }'
 
 endef
 

--- a/README.md
+++ b/README.md
@@ -89,6 +89,12 @@ sections = {
 }
 ```
 
+### ex.relative_filepath
+
+| File inside `cwd` | File outside `cwd` | File outside `cwd`, but inside `$HOME` |
+| :---: | :---: | :---: |
+|  |  |  |
+
 ### ex.git.branch
 
 | No git worktree | Worktree is commited | Worktree is changed |

--- a/lua/lualine/components/ex/relative_filename.lua
+++ b/lua/lualine/components/ex/relative_filename.lua
@@ -1,23 +1,70 @@
-local M = require('lualine.component'):extend()
+local M = require('lualine.ex.component'):extend({
+    external_prefix = nil,
+    filename_only_prefix = '…/',
+    shorten = { lenght = 5, exclude = nil },
+    -- -1 - never shorten; 0 - always shorten; >0 - shorten when longer then N symbols
+    max_length = 0.3,
+})
+
+local Path = require('plenary.path')
 
 ---Resolves the name of the current file relative to the current working directory.
 ---If the file is not in the one of subdirectories of the working directory, then its
 ---path will be returned with:
---- * prefix "/.../" in case when the file is not in the one of home subdirectories;
---- * prefix "~/" in case when the file is in one of home subdirectories.
+--- * prefix {external_prefix} in case when the file is not in the one of home
+---          subdirectories;
+--- * prefix "~" in case when the file is in one of home subdirectories.
+---Also it may shorten the file path according to {max_length}.
 function M:update_status()
-    local full_name = vim.fn.expand('%:p')
-    local name = vim.fn.expand('%:.')
-    if name == full_name then
-        name = vim.fn.expand('%:~')
+    local current_file = vim.fn.expand('%:p')
+    if current_file == '' then
+        return ''
     end
-    if name == full_name then
-        name = vim.fn.expand('%:t')
-        if #name > 0 then
-            name = '/.../' .. name
+
+    local filepath = Path:new(current_file):normalize(vim.fn.getcwd())
+    local prefix = (filepath == current_file) and self.options.external_prefix or ''
+
+    local max_length = self.options.max_length
+    max_length = (type(max_length) == 'function') and max_length(filepath) or max_length
+    max_length = (type(max_length) == 'number') and max_length or 0
+
+    if max_length < 0 then
+        return prefix .. filepath
+    end
+
+    -- calculate parameters for shorten algorithm
+    if max_length > 0 and max_length < 1 then
+        local width = (vim.o.laststatus == 3) and vim.o.columns or vim.api.nvim_win_get_width(0)
+        max_length = max_length * width
+    end
+    local exclude = self.options.shorten.exclude or {}
+    if exclude[-1] == nil then
+        table.insert(exclude, -1)
+    end
+    local shorten_length = self.options.shorten.length or 1
+
+    -- just apply user setting and shorten the filepath
+    if max_length == 0 then
+        return prefix .. Path:new(filepath):shorten(shorten_length, exclude)
+    end
+
+    -- calculate optimal filepath
+    while #filepath > max_length do
+        if shorten_length > 0 then
+            filepath = Path:new(filepath):shorten(shorten_length, exclude)
+            shorten_length = shorten_length - 1
+        else
+            filepath = Path:new(filepath):shorten(1, { -1 })
+            break
         end
     end
-    return name
+
+    if #filepath > max_length then
+        prefix = self.options.filename_only_prefix or ''
+        filepath = vim.fn.fnamemodify(filepath, ':t')
+    end
+
+    return prefix .. filepath
 end
 
 return M

--- a/tests/components/relative_filename_spec.lua
+++ b/tests/components/relative_filename_spec.lua
@@ -1,0 +1,197 @@
+local l = require('tests.ex.lualine')
+
+local mock = { o = {}, api = {} }
+local eq = assert.are.equal
+
+local component_name = 'ex.relative_filename'
+
+describe('relative_filename component', function()
+    local current_file
+    local cwd
+
+    before_each(function()
+        mock.expand = vim.fn.expand
+        vim.fn.expand = function(string, nosuf)
+            if string == '%:p' then
+                return current_file
+            else
+                return nil
+            end
+        end
+        mock.getcwd = vim.fn.getcwd
+        vim.fn.getcwd = function()
+            return cwd
+        end
+        mock.o.laststatus = vim.o.laststatus
+        mock.o.columns = vim.o.columns
+        mock.api.nvim_win_get_width = vim.api.nvim_win_get_width
+    end)
+
+    after_each(function()
+        vim.fn.expand = mock.expand
+        vim.fn.getcwd = mock.getcwd
+        vim.o.laststatus = mock.o.laststatus
+        vim.o.columns = mock.o.columns
+        vim.api.nvim_win_get_width = mock.api.nvim_win_get_width
+    end)
+
+    it('should contain only part after the cwd', function()
+        current_file = '/a/b/c.txt'
+        cwd = '/a/'
+        l.test_matched_component(component_name, function(ct)
+            eq('b/c.txt', ct.value)
+        end)
+    end)
+
+    it('should contain absolute path with prefix', function()
+        current_file = '/a/b/c.txt'
+        cwd = '/d/'
+        local opts = { external_prefix = '/...' }
+        l.test_matched_component(component_name, opts, function(ct)
+            eq(opts.external_prefix .. current_file, ct.value)
+        end)
+    end)
+
+    it('external prefix is empty by default', function()
+        current_file = '/a/b/c.txt'
+        cwd = '/d/'
+        l.test_matched_component(component_name, function(ct)
+            eq(current_file, ct.value)
+        end)
+    end)
+
+    it('should contain relate to the home path with ~ as a prefix', function()
+        current_file = vim.loop.os_homedir() .. '/a/b/c.txt'
+        cwd = '/d/'
+        l.test_matched_component(component_name, opts, function(ct)
+            eq('~/a/b/c.txt', ct.value)
+        end)
+    end)
+
+    describe('shorten algorithm', function()
+        cwd = '/'
+        current_file = cwd .. 'abcde/xyz/test.txt'
+
+        it("should shortify the path if it's longer than max_length", function()
+            local expected_value = 'a/x/test.txt'
+            local opts = { max_length = #expected_value }
+            l.test_matched_component(component_name, opts, function(ct)
+                eq(expected_value, ct.value)
+            end)
+        end)
+
+        it('should always shorten the path when {max_length} is 0', function()
+            local opts = { max_length = 0 }
+            l.test_matched_component(component_name, opts, function(ct)
+                eq('a/x/test.txt', ct.value)
+            end)
+        end)
+
+        it('should never shorten the path when {max_length} less 0', function()
+            local opts = { max_length = -1 }
+            l.test_matched_component(component_name, opts, function(ct)
+                eq('abcde/xyz/test.txt', ct.value)
+            end)
+        end)
+
+        it(
+            'if the {max_length} is a function then it should be invoked with the current path',
+            function()
+                local passed_arg
+                local opts = {
+                    max_length = function(path)
+                        passed_arg = path
+                        return 0
+                    end,
+                }
+                l.test_matched_component(component_name, opts, function(ct)
+                    eq('a/x/test.txt', ct.value)
+                    eq('abcde/xyz/test.txt', passed_arg)
+                end)
+            end
+        )
+
+        it(
+            'should contain only specified count of symbols in every directory of the path',
+            function()
+                local opts = { shorten = { length = 2 }, max_length = 0 }
+                l.test_matched_component(component_name, opts, function(ct)
+                    eq('ab/xy/test.txt', ct.value)
+                end)
+            end
+        )
+
+        it('should never shortify the file name', function()
+            local opts = { shorten = { length = 1, exclude = { 1 } }, max_length = 0 }
+            l.test_matched_component(component_name, opts, function(ct)
+                eq('abcde/x/test.txt', ct.value)
+            end)
+        end)
+
+        it('should decrease the {shorten.length} until it become enough', function()
+            local opts = { shorten = { length = 3 }, max_length = #current_file - 5 }
+            l.test_matched_component(component_name, opts, function(ct)
+                eq('ab/xy/test.txt', ct.value)
+            end)
+        end)
+
+        it('should ignore the {shorten.exclude} the {shorten.length} == 1 is not enough', function()
+            local opts = { shorten = { exclude = { 1 } }, max_length = #current_file - 5 }
+            l.test_matched_component(component_name, opts, function(ct)
+                eq('a/x/test.txt', ct.value)
+            end)
+        end)
+
+        it(
+            "should return only file name with prefix if all other options didn't help achive the {max_length}",
+            function()
+                local opts = { filename_only_prefix = '.../', max_length = 1 }
+                l.test_matched_component(component_name, opts, function(ct)
+                    eq(opts.filename_only_prefix .. 'test.txt', ct.value)
+                end)
+            end
+        )
+
+        describe('when vim.o.laststatus == 3', function()
+            vim.o.laststatus = 3
+            vim.o.columns = #current_file * 10
+            it(
+                'should not shortify component if the full name less than max_length * vim.o.columns',
+                function()
+                    local opts = { max_length = 0.5 }
+                    l.test_matched_component(component_name, opts, function(ct)
+                        eq('abcde/xyz/test.txt', ct.value)
+                    end)
+                end
+            )
+            it(
+                'should shortify component if the full name longer than max_length * vim.o.columns',
+                function()
+                    local expected_value = 'a/x/test.txt'
+                    local opts = { max_length = #expected_value / vim.o.columns }
+                    l.test_matched_component(component_name, opts, function(ct)
+                        eq('a/x/test.txt', ct.value)
+                    end)
+                end
+            )
+        end)
+
+        describe('when vim.o.laststatus is not 3', function()
+            vim.o.laststatus = 2
+            vim.o.columns = #current_file * 10
+            it(
+                'should shortify component if the full name longer than max_length * nvim_win_get_width(0)',
+                function()
+                    vim.api.nvim_win_get_width = function()
+                        return #current_file * 2
+                    end
+                    local expected_value = 'a/x/test.txt'
+                    local opts = { max_length = #expected_value / vim.api.nvim_win_get_width(0) }
+                    l.test_matched_component(component_name, opts, function(ct)
+                        eq(expected_value, ct.value)
+                    end)
+                end
+            )
+        end)
+    end)
+end)

--- a/tests/ex/busted.lua
+++ b/tests/ex/busted.lua
@@ -1,11 +1,22 @@
 ---@diagnostic disable: lowercase-global
 local M = {}
 
+assert.is_blank = function(str, msg)
+    if type(str) == 'string' then
+        if string.gmatch(str, '^%s*$') then
+            return
+        else
+            error(string.format('The string "%s" is not blank.%s', str, msg or ''))
+        end
+    end
+    error(string.format('The {str} has wrong type %s instead of "string".%s', type(str), msg or ''))
+end
+
 function M.ignore_it(desc, fun, reason)
     print('!!!IGNORED!!!', desc, '\nReason: ', reason or '')
 end
 
-function M.except_it(desc, fun)
+function M.it(desc, fun)
     require('plenary.busted').it(desc, fun)
 end
 
@@ -41,7 +52,7 @@ function M.eventually(test, timeout_sec)
     end
 end
 
-function M.withClue(clue, test)
+function M.with_clue(clue, test)
     local ok, err = pcall(test)
     if not ok then
         error(string.format('Clue: [%s] Error: %s', clue, err))

--- a/tests/init.lua
+++ b/tests/init.lua
@@ -22,10 +22,25 @@ lspconfig.vimls.setup({
 })
 
 -- choose ex component for demo:
-local demo_component = vim.env.component or 'ex.cwd'
+local demo_component = { vim.env.component or 'ex.cwd' }
+if vim.env.component_opts then
+    local ok, demo_options = pcall(vim.json.decode, vim.env.component_opts)
+    if not ok then
+        error(
+            string.format(
+                'Wrong value of the component_opts=%s. It should be a valid json object. Error:\n%s',
+                vim.env.component_opts,
+                vim.inspect(err)
+            )
+        )
+    end
+    if type(demo_options) == 'table' then
+        demo_component = vim.tbl_extend('keep', demo_component, demo_options)
+    end
+end
 
 local function demo_component_name()
-    return string.format("This is a demo of the '%s' component:", demo_component)
+    return string.format("This is a demo of the '%s' component:", demo_component[1])
 end
 
 -- setup statusline with ex component:


### PR DESCRIPTION
### ex.relative_filename

This component shows a `filename`: a file name and a path to the current file relative to the
current working directory, and may be used effectively together with [ex.cwd](#ex.cwd). The
`filename` has a prefix, which shows a file's place in the file system relative to the `cwd`:

| File path relative to `cwd` | Options | Component example |
| :---: | :---: | ---: | 
| inside `cwd`                      | |<img src = "https://github.com/dokwork/lualine-ex/assets/6939832/af8ab32f-58f2-4f11-a2aa-6f519095c693" height=18 />|
| outside `cwd`                     | `external_prefix = "/..."` |<img src = "https://github.com/dokwork/lualine-ex/assets/6939832/7ada40a6-19c0-4811-ad59-ba3e08b40c44" height=18 />|
| outside `cwd`, but inside `$HOME` | |<img src = "https://github.com/dokwork/lualine-ex/assets/6939832/71a391aa-fb77-4f1a-88c8-76ed30b3907f" height=18 />|

Some path may be very long and takes significant part in the statusline. It's possible to specify the
{max_length} of the filename. To achieve that the follow algorithm is used:

- every part of the path is shorten till the {shorten.length} except parts from the {shorten.exclude}
  list;
- then the {shorten.length} will be repeatedly decreased until 1 or until the {max_length} will be 
  achieved;
- if it's not enough then the {exclude} setting will be ignored and all parts will be shorten;
- if the result is still longer than {max_length} than only the file name will be used with the prefix
  {filename_only_prefix}.

Example of the shorten filename with follow options `{ shorten: { length = 3, exclude = { 1 } } }`:

| Space for component enough to show ...| Component example |
| :--- | ---: |
| the whole path |<img src = "https://github.com/dokwork/lualine-ex/assets/6939832/af8ab32f-58f2-4f11-a2aa-6f519095c693" height=18 />|
| the path with specified options (`shorten.length` = 3) |<img src = "https://github.com/dokwork/lualine-ex/assets/6939832/378bf6e2-0a22-41d2-86de-62dd13292c11" height=18 />|
| the path with `shorten.length` = 2 |<img src = "https://github.com/dokwork/lualine-ex/assets/6939832/61d10458-9dfc-401f-a0a1-2b14111f0e14" height=18 />|
| the path with `shorten.length` = 1 |<img src = "https://github.com/dokwork/lualine-ex/assets/6939832/2553d511-d3bf-42eb-a86e-5b154513d517" height=18 />|
| the path ignoring `exclude` section |<img src = "https://github.com/dokwork/lualine-ex/assets/6939832/8520b046-299d-4668-a08b-cba6f13c1a87" height=18 />|
| only the file name |<img src = "https://github.com/dokwork/lualine-ex/assets/6939832/f26b9d9d-417e-4984-a1cb-077dce4cfdfd" height=18 />|

The {max_length} may be a number, or a function which receives the current component value and
returns a number:
 - Every value less than 0 means that the filename never should be shorten;
 - Zero means that filename should be always shorten;
 - A value more or equal to 1 represents a length, after which the filename should be shorten;
 - A value between 0 and 1 represents a fraction of the current window width if the {laststatus} == 2, 
   or a fraction of the terminal width.

**Default configuration:**
```lua
{
    -- The prefix which is used when the current file is outside cwd
    external_prefix = nil,

    -- The prefix which is used when the length of the filename after shorten
    -- is longer than {max_length}
    filename_only_prefix = '…/',

    -- The max length of the component value.
    -- < 0          - never shorten; 
    -- 0            - always shorten; 
    -- > 0 and  < 1 - shorten when longer than {max_length} * {vim.o.columns} 
    --                for {laststatus} == 3;
    --                and shorten when longer than 
    --                {max_length} * {vim.api.nvim_win_get_width(0)} overwise; 
    -- >= 1         - shorten when longer then N symbols;
    max_length = 0.3,

    -- The configuration of the shorten algorithm.
    shorten = { 
        -- The count of letters, which will be taken from every part of the path
        lenght = 5, 
        -- The list of indexes of filename parts, which should not be shorten at all
        -- (the file name { -1 } is always excluded)
        exclude = nil 
    },
}
```

_`ex.relative_filename` component doesn't provide options to show file states, because it easily
possible to do with standard approach:_

```lua
-- readonly mode indicator example:
{
    '%{""}',
    draw_empty = true,
    icon = { '' },
    cond = function()
        return not vim.bo.modifiable
    end,
}
```

