### PR TITLE
feat: function to close not used lsp clients

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,10 +18,10 @@ jobs:
       uses: actions/checkout@v3
 
     - name: Run StyLua
-      uses: JohnnyMorganz/stylua-action@1.0.0
+      uses: JohnnyMorganz/stylua-action@v3
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
-        version: 0.13.1
+        version: 0.19.0
         args: --check .
 
   test:

--- a/README.md
+++ b/README.md
@@ -316,11 +316,12 @@ installed).
 When some of already run servers is not active for the current buffer, it is in _disabled_ state.
 The component in _disabled_ state has a color specified in the option `disabled_color`.
 
-If no on lsp client is run, the component shows only `lsp_is_off` icon.
+If no one lsp client is run, the component shows only `lsp_is_off` icon.
+
+You may double click by this component to close all not used lsp clients.
 
 The `ex.lsp.all` component has the same options as the [ex.lsp.single](#exlspsingle) component, 
-with additional option `only_attached`, which can be used to show only attached to the current buffer 
-clients:
+with few additional:
 
 ```lua
 sections = {
@@ -332,6 +333,12 @@ sections = {
 
       -- If true then only clients attached to the current buffer will be shown:
       only_attached = false,
+
+      -- If true then every closed client will be echoed:
+      notify_enabled = true
+      
+      -- A name of highlight group which should be used in echo:
+      notify_hl = 'Comment'
     }
   }
 }

--- a/lua/lualine/components/ex/lsp/all.lua
+++ b/lua/lualine/components/ex/lsp/all.lua
@@ -19,6 +19,7 @@ local AllLsp = require('lualine.ex.component'):extend(
         is_enabled = function(component)
             return not ex.is_empty(component:__clients())
         end,
+        on_click = require('lualine.ex.lsp').stop_inactive_clients
     })
 )
 

--- a/lua/lualine/ex/lsp.lua
+++ b/lua/lualine/ex/lsp.lua
@@ -1,0 +1,28 @@
+local M = {}
+
+M.stop_inactive_clients = function(opts)
+    opts = opts or {}
+    local hl = opts.debug_hl or 'Comment'
+    local function notify(msg, ...)
+        if opts.notify_enabled then
+            local arg = { ... }
+            msg = string.format('[lualine.ex.lsp] ' .. msg, unpack(arg))
+            vim.api.nvim_echo({ { msg, hl } }, true, {})
+        end
+    end
+    local were_stopped = 0
+    for _, client in pairs(vim.lsp.get_active_clients()) do
+        if not next(client.attached_buffers) then
+            notify('Stop the client %d %s', client.id, client.name or 'UNKNOWN')
+            vim.lsp.stop_client(client.id)
+            were_stopped = were_stopped + 1
+        end
+    end
+    if were_stopped == 0 then
+        notify('No one inactive client')
+    else
+        notify('%d clients were stop', were_stopped)
+    end
+end
+
+return M

--- a/lua/lualine/ex/lsp.lua
+++ b/lua/lualine/ex/lsp.lua
@@ -1,10 +1,14 @@
 local M = {}
 
-M.stop_inactive_clients = function(opts)
+---Iterates over active lsp clients and stops every client without attached buffers.
+---@param opts table
+---@field notify_enabled boolean true enables echo about every stopped client.
+---@field notify_hl HighlightGroup a name of the highlight which should be used in echo.
+M.stop_unused_clients = function(opts)
     opts = opts or {}
-    local hl = opts.debug_hl or 'Comment'
+    local hl = opts.notify_hl or 'Comment'
     local function notify(msg, ...)
-        if opts.notify_enabled then
+        if opts.notify_enabled == true then
             local arg = { ... }
             msg = string.format('[lualine.ex.lsp] ' .. msg, unpack(arg))
             vim.api.nvim_echo({ { msg, hl } }, true, {})
@@ -19,9 +23,9 @@ M.stop_inactive_clients = function(opts)
         end
     end
     if were_stopped == 0 then
-        notify('No one inactive client')
+        notify('No one unused client')
     else
-        notify('%d clients were stop', were_stopped)
+        notify('%d client%s stopped', were_stopped, (were_stopped > 1) and 's were' or ' was')
     end
 end
 

--- a/tests/components/lsp_spec.lua
+++ b/tests/components/lsp_spec.lua
@@ -61,9 +61,7 @@ describe('ex.lsp.single component', function()
             vim.mock.lsp.get_active_clients.returns({ lua_lsp })
             -- make the component enabled:
             vim.mock.lsp.get_buffers_by_client_id.returns({ vim.fn.bufnr('%') })
-            -- when:
-            local rc = l.render_component(component_name)
-            local ctbl = l.match_rendered_component(rc)
+
             l.test_matched_component(component_name, function(ctbl)
                 eq(lua_lsp.name, ctbl.value, 'Wrong value in the rendered component.')
                 eq(lua_icon.icon, ctbl.icon, 'Wrong icon in the rendered component.')


### PR DESCRIPTION
It would be good to be able to close all not used lsp clients to save memory. This PR introduces a function to do so, and set that function as double-click handler for `ex.lsp.all` component.