### PR TITLE
Few fixes and the new function to crop components

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ possible to do with standard approach:_
 
 ### ex.git.branch
 
-| No git worktree | Worktree is commited | Worktree is changed |
+| No git worktree | Worktree is committed | Worktree is changed |
 | :---: | :---: | :---: |
 | <img src="https://github.com/dokwork/lualine-ex/assets/6939832/23b34d15-c711-49dc-a94b-0a27aab0d436" height=18 />| <img src="https://github.com/dokwork/lualine-ex/assets/6939832/6e66a6f5-84ed-45a1-a03f-f5592c670ec1" height=18 />| <img src="https://github.com/dokwork/lualine-ex/assets/6939832/0d3a41b1-6538-4d34-b890-c3b978f35c6d" height=18 />|
 
@@ -216,7 +216,7 @@ component depends on the state of the git worktree. The component can show diffe
 git worktree:
 
   - `changed` means that at least one uncommitted change exists;
-  - `commited` means that everything is committed, and no one tracked file is changed;
+  - `committed` means that everything is committed, and no one tracked file is changed;
   - `disabled` means that the `cwd` is not under git control. 
 
 ```lua
@@ -236,7 +236,7 @@ sections = {
       -- The colors for possible states:
       colors = {
           changed = { fg = 'orange' },
-          commited = { fg = 'green' },
+          committed = { fg = 'green' },
       },
 
       -- The color for the disabled component:

--- a/lua/lualine/components/ex/cwd.lua
+++ b/lua/lualine/components/ex/cwd.lua
@@ -21,6 +21,9 @@ function Cwd:update_status()
     local depth = self.options.depth
     local sep = package.config:sub(1, 1)
     local dirs = vim.split(cwd, sep, { plain = true, trimempty = true })
+    if #dirs <= math.abs(depth) then
+        return cwd
+    end
     local prefix = (self.options.prefix and depth > 0) and self.options.prefix .. sep or ''
     local max_length = ex.max_length(self.options.max_length, cwd) or 0
 
@@ -38,7 +41,7 @@ function Cwd:update_status()
         else
             return ''
         end
-    until #cwd < max_length
+    until vim.fn.strdisplaywidth(cwd) < max_length
     return prefix .. cwd .. sep
 end
 

--- a/lua/lualine/components/ex/git/branch.lua
+++ b/lua/lualine/components/ex/git/branch.lua
@@ -1,22 +1,34 @@
 local Git = require('lualine.ex.git_provider')
+local ex = require('lualine.ex')
 
 ---@class GitBranchColors
 ---@field changed Color
 ---@field commited Color
 
+---@class CropOptions
+---@field side? string 'left' | 'right'
+---@field stub? string
+
 ---@class GitBranchOptions: ExComponentOptions
 ---@field icon Icon
 ---@field sync boolean
 ---@field colors GitBranchColors
+---@field max_length? number|fun(): number
 local default_options = {
     icon = { ' ' },
     colors = {
         changed = { fg = 'orange' },
         commited = { fg = 'green' },
     },
+    max_length = nil,
+    crop = {
+        stub = '…',
+        side = nil,
+    },
     is_enabled = function(component)
         return component.git():git_root() ~= nil
     end,
+    fmt = ex.crop,
 }
 
 ---Singleton instance for any non git paths

--- a/lua/lualine/components/ex/git/branch.lua
+++ b/lua/lualine/components/ex/git/branch.lua
@@ -3,7 +3,7 @@ local ex = require('lualine.ex')
 
 ---@class GitBranchColors
 ---@field changed Color
----@field commited Color
+---@field committed Color
 
 ---@class CropOptions
 ---@field side? string 'left' | 'right'
@@ -18,7 +18,7 @@ local default_options = {
     icon = { ' ' },
     colors = {
         changed = { fg = 'orange' },
-        commited = { fg = 'green' },
+        committed = { fg = 'green' },
     },
     max_length = nil,
     crop = {
@@ -57,7 +57,7 @@ function GitBranch:pre_init()
         if is_worktree_changed == nil then
             return self.options.disabled_color
         end
-        return is_worktree_changed and self.options.colors.changed or self.options.colors.commited
+        return is_worktree_changed and self.options.colors.changed or self.options.colors.committed
     end
 end
 

--- a/lua/lualine/components/ex/relative_filename.lua
+++ b/lua/lualine/components/ex/relative_filename.lua
@@ -16,7 +16,7 @@ local Path = require('plenary.path')
 --- * prefix {external_prefix} in case when the file is not in the one of home
 ---          subdirectories;
 --- * prefix "~" in case when the file is in one of home subdirectories.
----Also it may shorten the file path according to {max_length}.
+---Also, it may shorten the file path according to {max_length}.
 function M:update_status()
     local current_file = vim.fn.expand('%:p')
     if current_file == '' then

--- a/lua/lualine/ex/component.lua
+++ b/lua/lualine/ex/component.lua
@@ -143,7 +143,7 @@ function Ex:draw(default_highlight, is_focused)
     self.default_hl = default_highlight
     local status = self:update_status(is_focused)
     if self.options.fmt then
-        status = self.options.fmt(status or '')
+        status = self.options.fmt(status or '', self)
     end
     -- we have two option to turn icon off:
     -- 1. turn off all icons for components

--- a/tests/components/cwd_spec.lua
+++ b/tests/components/cwd_spec.lua
@@ -25,6 +25,14 @@ describe('cwd component', function()
         vim.api.nvim_win_get_width = mock.api.nvim_win_get_width
     end)
 
+    it('should do nothing when path less or equal to {depth}', function()
+        cwd = '/a/b/c/'
+        local opts = { depth = 3 }
+        l.test_matched_component(component_name, opts, function(ct)
+            eq(cwd, ct.value)
+        end)
+    end)
+
     it('should contain only {depth} parts of the cwd from the end', function()
         cwd = '/a/b/c/d/'
         local opts = { depth = 3 }
@@ -45,9 +53,8 @@ describe('cwd component', function()
     )
 
     describe('shorten algorithm', function()
-        cwd = '/abcd/efghi/jklmn/opqr/'
-
         it('should decrease the {depth} until the cwd less than {max_length}', function()
+            cwd = '/abcd/efghi/jklmn/opqr/'
             local expected_value = '…/jklmn/opqr/'
             local opts = { max_length = #expected_value, depth = 3 }
             l.test_matched_component(component_name, opts, function(ct)
@@ -56,9 +63,19 @@ describe('cwd component', function()
         end)
 
         it('should be empty if the {max_length} is 0', function()
+            cwd = '/abcd/efghi/jklmn/opqr/'
             local opts = { max_length = 1 }
             l.test_matched_component(component_name, opts, function(ct)
                 eq('', ct.value)
+            end)
+        end)
+
+        it('should count symbols, not bytes, to compare with max_length', function()
+            -- this path has less symbols than bytes:
+            cwd = '/абв/гд/'
+            local opts = { max_length = 9 }
+            l.test_matched_component(component_name, opts, function(ct)
+                eq(cwd, ct.value)
             end)
         end)
     end)

--- a/tests/components/git_branch_spec.lua
+++ b/tests/components/git_branch_spec.lua
@@ -97,10 +97,10 @@ describe('ex.git.branch component', function()
         end)
 
         it('rendered component should have "committed" color', function()
-            local commited_color = { fg = 'blue' }
-            local opts = l.opts({ colors = { commited = commited_color }, sync = true })
+            local committed_color = { fg = 'blue' }
+            local opts = l.opts({ colors = { committed = committed_color }, sync = true })
             l.test_matched_component(component_name, opts, function(ctbl)
-                l.eq_colors(commited_color.fg, ctbl.color.fg)
+                l.eq_colors(committed_color.fg, ctbl.color.fg)
             end)
         end)
     end)

--- a/tests/components/git_branch_spec.lua
+++ b/tests/components/git_branch_spec.lua
@@ -77,24 +77,31 @@ describe('ex.git.branch component', function()
             eq('%' .. branch, c:update_status())
         end)
 
+        it('should crop branch name', function()
+            -- let's use symbols which are not equal to one byte,
+            -- to bu sure that crop works correctly
+            local branch = 'абвгд'
+            git:new_branch(branch)
+            local opts = { max_length = 4, crop = { side = 'right', stub = '!' } }
+            l.test_matched_component(component_name, opts, function(ctbl)
+                eq('абв!', ctbl.value)
+            end)
+        end)
+
         it('a rendered component should have the branch name and the icon', function()
             git:checkout('main')
-            local rendered_component = l.render_component(component_name)
-            local ctbl = l.match_rendered_component(rendered_component)
-            eq('', ctbl.icon, 'Wrong icon in: ' .. rendered_component)
-            eq('main', ctbl.value, 'Wrong value in: ' .. rendered_component)
+            l.test_matched_component(component_name, opts, function(ctbl)
+                eq('', ctbl.icon)
+                eq('main', ctbl.value)
+            end)
         end)
 
         it('rendered component should have "committed" color', function()
             local commited_color = { fg = 'blue' }
             local opts = l.opts({ colors = { commited = commited_color }, sync = true })
-            local rendered_component = l.render_component(component_name, opts)
-            local ctbl = l.match_rendered_component(rendered_component)
-            l.eq_colors(
-                commited_color.fg,
-                ctbl.color.fg,
-                'Wrong color for component in ' .. rendered_component
-            )
+            l.test_matched_component(component_name, opts, function(ctbl)
+                l.eq_colors(commited_color.fg, ctbl.color.fg)
+            end)
         end)
     end)
 end)

--- a/tests/ex_spec.lua
+++ b/tests/ex_spec.lua
@@ -105,3 +105,49 @@ describe('max_length', function()
         end)
     end)
 end)
+
+describe('crop', function()
+    it('should return nil if max_length is not specified', function()
+        eq(nil, ex.crop())
+    end)
+
+    it('should crop the value from right side', function()
+        local component = { options = {} }
+        local value = 'example'
+        eq('exam…', ex.crop({ side = 'right', max_length = 5 })(value, component))
+    end)
+
+    it('should crop the value from left side', function()
+        local component = { options = {} }
+        local value = 'example'
+        eq('…mple', ex.crop({ side = 'left', max_length = 5 })(value, component))
+    end)
+
+    it('should crop the value from left side for a component in sections a,b,c', function()
+        for _, section in ipairs({ 'a', 'b', 'c' }) do
+            local component = { options = { self = { section = section } } }
+            local value = 'example'
+            eq('…mple', ex.crop({ max_length = 5 })(value, component))
+        end
+    end)
+
+    it('should crop the value from right side for a component in sections x,y,z', function()
+        for _, section in ipairs({ 'x', 'y', 'z' }) do
+            local component = { options = { self = { section = section } } }
+            local value = 'example'
+            eq('exam…', ex.crop({ max_length = 5 })(value, component))
+        end
+    end)
+
+    it('should replace an extra part by the stub', function()
+        local component = { options = {} }
+        local value = 'example'
+        eq('---le', ex.crop({ side = 'left', stub = '---', max_length = 5 })(value, component))
+    end)
+
+    it('should follow section logic in case of wrong value of the side option', function()
+        local component = { options = { self = { section = 'a' } } }
+        local value = 'example'
+        eq('!mple', ex.crop({ side = 'wrong value', stub = '!', max_length = 5 })(value, component))
+    end)
+end)

--- a/tests/ex_spec.lua
+++ b/tests/ex_spec.lua
@@ -107,47 +107,61 @@ describe('max_length', function()
 end)
 
 describe('crop', function()
-    it('should return nil if max_length is not specified', function()
-        eq(nil, ex.crop())
-    end)
-
-    it('should crop the value from right side', function()
+    it('should return passed string if max_length is not specified', function()
         local component = { options = {} }
-        local value = 'example'
-        eq('exam…', ex.crop({ side = 'right', max_length = 5 })(value, component))
+        local str = 'example'
+        eq(str, ex.crop(str, component))
     end)
 
-    it('should crop the value from left side', function()
-        local component = { options = {} }
-        local value = 'example'
-        eq('…mple', ex.crop({ side = 'left', max_length = 5 })(value, component))
+    it('should crop the string from the right side', function()
+        local component = { options = { crop = { side = 'right' }, max_length = 5 } }
+        local str = 'example'
+        eq('exam…', ex.crop(str, component))
     end)
 
-    it('should crop the value from left side for a component in sections a,b,c', function()
-        for _, section in ipairs({ 'a', 'b', 'c' }) do
-            local component = { options = { self = { section = section } } }
-            local value = 'example'
-            eq('…mple', ex.crop({ max_length = 5 })(value, component))
+    it('should crop the string from the left side', function()
+        local component = { options = { crop = { side = 'left' }, max_length = 5 } }
+        local str = 'example'
+        eq('…mple', ex.crop(str, component))
+    end)
+
+    it(
+        'should crop the string from the left side when the component s in sections a,b,c',
+        function()
+            for _, section in ipairs({ 'a', 'b', 'c' }) do
+                local component = { options = { max_length = 5, self = { section = section } } }
+                local str = 'example'
+                eq('…mple', ex.crop(str, component))
+            end
         end
-    end)
+    )
 
-    it('should crop the value from right side for a component in sections x,y,z', function()
-        for _, section in ipairs({ 'x', 'y', 'z' }) do
-            local component = { options = { self = { section = section } } }
-            local value = 'example'
-            eq('exam…', ex.crop({ max_length = 5 })(value, component))
+    it(
+        'should crop the string from the right side when the component is in sections x,y,z',
+        function()
+            for _, section in ipairs({ 'x', 'y', 'z' }) do
+                local component = { options = { max_length = 5, self = { section = section } } }
+                local str = 'example'
+                eq('exam…', ex.crop(str, component))
+            end
         end
-    end)
+    )
 
     it('should replace an extra part by the stub', function()
-        local component = { options = {} }
-        local value = 'example'
-        eq('---le', ex.crop({ side = 'left', stub = '---', max_length = 5 })(value, component))
+        local component = { options = { crop = { side = 'left', stub = '---' }, max_length = 5 } }
+        local str = 'example'
+        eq('---le', ex.crop(str, component))
     end)
 
-    it('should follow section logic in case of wrong value of the side option', function()
-        local component = { options = { self = { section = 'a' } } }
-        local value = 'example'
-        eq('!mple', ex.crop({ side = 'wrong value', stub = '!', max_length = 5 })(value, component))
+    it('should ignore side in case of wrong value', function()
+        local component = {
+            options = {
+                crop = { side = 'wrong value', stub = '!' },
+                max_length = 5,
+                self = { section = 'a' },
+            },
+        }
+        local str = 'example'
+        eq('!mple', ex.crop(str, component))
     end)
 end)


### PR DESCRIPTION
## The new function `crop`
```lua
require('lualine.ex').crop({str}, {cmp})
```

Crops the component when its length longer than {max_length} option (if it's
specified).

**Parameters:**

    * {str}           (string) the current value of the component.
    * {cmp}           (table) the component object with follow options:
        * max_length  (number) the maximum count of symbols in the component, 
                      after which the component will be cropped. If it's absent
                      or less or equal zero, the function returns nil. Default
                      to nil.
        * crop        (table) crop options:
            * stub    (string) a string which will be used instead of cropped
                      part. Default to '…'.
            * side    ('left' | 'right') a side from which a value will be
                      cropped. If absent, it will be calculated from the
                      component's section: for sections a,b,c a component value
                      will be cropped from the left; for sections x,y,z from the
                      right.

**Return:**

Original or cropped string.

This function is applied to the ex.git.branch component as the fmt function by default.

## Fix of the `ex.component`

Reference to the component is passed to the `fmt` function.

## Fix `ex.git.branch` component !
 
Fixed typo in {committed} option. This is breaking change!

## Fix `ex.cwd` component

The count of **symbols** is used to follow the `max_length` options instead of the
count of **bytes**.