### PR TITLE
The new component: ex.lsp.null_ls

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,6 @@ on:
       - main
   pull_request:
     paths-ignore:
-      - '**.md'
       - 'LICENSE'
 
 jobs:

--- a/Makefile
+++ b/Makefile
@@ -10,10 +10,16 @@ export XDG_CONFIG_HOME=$(ROOT)/config
 
 START=$(XDG_CONFIG_HOME)/nvim/pack/dokwork/start
 
+# === Dependencies ===
+# Common for the plugin
 PLENARY=$(START)/plenary.nvim
 DEVICONS=$(START)/nvim-web-devicons
-LSPCONFIG=$(START)/lualine.nvim
 LUALINE=$(START)/nvim-lspconfig
+
+# Specific for components:
+LSPCONFIG=$(START)/lualine.nvim
+NULL_LS=$(START)/null-ls.nvim
+# ====================
 
 define HELP
 make [command]\nCommands:
@@ -44,6 +50,10 @@ You can pass a path to file which should be opened in demo:
 Also, you can pass custom options to the demo component as a json:
 > make demo component=ex.cwd component_opts='{ "depth": 1 }'
 
+If a component needs additional plugin, you can install it if specify
+'plugin' name as <github user>/<github repo>:
+> make install plugin nvimtools/none-ls.nvim
+
 endef
 
 help: export HELP:=$(HELP)
@@ -61,9 +71,13 @@ fmt:
 
 install:
 	@[ -d $(PLENARY) ] || git clone --depth 1 https://github.com/nvim-lua/plenary.nvim $(PLENARY)
-	@[ -d $(DEVICONS)/ ] || git clone --depth 1 https://github.com/nvim-tree/nvim-web-devicons $(DEVICONS)
-	@[ -d $(LSPCONFIG)/ ] || git clone --depth 1 https://github.com/neovim/nvim-lspconfig $(LSPCONFIG)
-	@[ -d $(LUALINE)/ ] || git clone --depth 1 https://github.com/nvim-lualine/lualine.nvim $(LUALINE)
+	@[ -d $(DEVICONS) ] || git clone --depth 1 https://github.com/nvim-tree/nvim-web-devicons $(DEVICONS)
+	@[ -d $(LSPCONFIG) ] || git clone --depth 1 https://github.com/neovim/nvim-lspconfig $(LSPCONFIG)
+	@[ -d $(LUALINE) ] || git clone --depth 1 https://github.com/nvim-lualine/lualine.nvim $(LUALINE)
+	@[ -d $(NULL_LS) ] || git clone --depth 1 https://github.com/nvimtools/none-ls.nvim $(NULL_LS)
+ifdef plugin
+	@[ -d $(START)/$(notdir $(plugin)) ] || git clone --depth 1 https://github.com/$(plugin) $(START)/$(notdir $(plugin))
+endif
 
 test: install
 	nvim --headless -u tests/init.lua -c "PlenaryBustedDirectory  tests/$(only) {minimal_init='tests/init.lua',sequential=true}"

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ for `lualine.nvim` with additional components.
     - [ex.git.branch](#exgitbranch)
     - [ex.lsp.single](#exlspsingle)
     - [ex.lsp.all](#exlspall)
+    - [ex.lsp.null_ls](#exlspnull_ls)
  - [🛠️ Tools](#tools)
 
 ## 📥 <a name="installation">Installation</a>
@@ -470,6 +471,46 @@ on_click = function(clicks, button, modified)
     end
 end
 ```
+
+### ex.lsp.null_ls
+
+This component shows names of the
+[null-ls](https://github.com/nvimtools/none-ls.nvim) sources according to the specified
+[`query`](https://github.com/nvimtools/none-ls.nvim/blob/main/doc/SOURCES.md#get_sourcequery).
+By default, it shows names of all sources actual to the current buffer. All
+duplicated names are merged.
+
+```lua
+sections = {
+  lualine_a = {
+    {
+      'ex.lsp.null_ls',
+
+      -- The table or function that returns the table with the source query.
+      -- By default it shows only actual sorces. To show all registered sources
+      -- you can use just empty table:
+      -- query = {}
+      query = function()
+        return { filetype = vim.bo.filetype }
+      end,
+
+      -- The string separator between names
+      source_names_separator = ',',
+
+      -- The color for the disabled component:
+      disabled_color = { fg = 'grey' }
+
+      -- The color for the icon of the disabled component:
+      disabled_icon_color = { fg = 'grey' }
+    }
+  }
+}
+```
+
+No one source:&nbsp;<img height="18" alt="null-ls-disabled" src="https://github.com/dokwork/lualine-ex/assets/6939832/04ce4a14-a3f9-4d90-a229-d19b78fa7c11">
+The `jq` and the `spell` sources are active for the current buffer:<img height="18" alt="nulll-ls-enabled" src="https://github.com/dokwork/lualine-ex/assets/6939832/dda7dbb4-8647-49a2-8c28-8d29a617c2b9">
+
+
 
 ## 🛠️ <a name="tools">Tools</a>
 This plugin provide additional tools to help you create your own components. Read more details here:

--- a/lua/lualine/components/ex/lsp/all.lua
+++ b/lua/lualine/components/ex/lsp/all.lua
@@ -28,8 +28,6 @@ local AllLsp =
 function AllLsp:pre_init()
     self.options.component_name = 'ex_lsp_all'
     self.components = {}
-    -- will be used to avoid duplicate highlights:
-    self.__hls_cache = {}
     self.options.on_click = self.options.on_click
         or function(clicks, button, modified)
             if clicks > 1 then
@@ -71,7 +69,7 @@ function AllLsp:update_status(is_focused)
                 lsp = SingleLsp:new({
                     client = client,
                     component_name = str_escape('inner_lsp_' .. client.name),
-                    hls_cache = self.__hls_cache,
+                    hls_cache = self.hls_cache,
                     self = self.options.self,
                     icons = self.options.icons,
                     icons_enabled = self.options.icons_enabled,

--- a/lua/lualine/components/ex/lsp/null_ls.lua
+++ b/lua/lualine/components/ex/lsp/null_ls.lua
@@ -1,0 +1,76 @@
+local log = require('plenary.log').new({ plugin = 'ex.lsp.null-ls' })
+
+-- we should be ready to three possible cases:
+-- * when null-ls is not loaded we should load it only on demand;
+-- * when null-ls is not installed we should mock it to avoid errors;
+-- * when it is installed and loaded we should it use it.
+local null_ls = setmetatable({}, {
+    __index = function(self, key)
+        -- attempt to lazy load null-ls plugin
+        if rawget(self, 'is_installed') == nil then
+            local is_installed, null_ls = pcall(require, 'null-ls')
+            rawset(self, 'is_installed', is_installed)
+            rawset(self, 'null_ls', null_ls)
+            if is_installed then
+                log.debug('null-ls is installed')
+            else
+                log.warn('null-ls is not installed.')
+            end
+        end
+        -- return original plugin if it's installed
+        if rawget(self, 'is_installed') then
+            return rawget(self, 'null_ls')[key]
+        end
+        -- return mock:
+        if key == 'get_source' then
+            return {}
+        elseif key == 'is_registered' then
+            return false
+        else
+            return nil
+        end
+    end,
+})
+
+local NullLS = require('lualine.ex.component'):extend({
+    icon = '',
+    query = function()
+        return { filetype = vim.bo.filetype }
+    end,
+    component_name = 'ex_lsp_null_ls',
+    source_names_separator = ',',
+    is_enabled = function(component)
+        return null_ls.is_registered(component:get_query())
+    end,
+})
+
+function NullLS:get_query()
+    if type(self.options.query) == 'function' then
+        return self.options.query()
+    else
+        return self.options.query
+    end
+end
+
+-- get sources by query, and concatenate their unique names with {source_names_separator}
+function NullLS:update_status()
+    local sources = null_ls.get_source(self:get_query())
+    log.fmt_debug(
+        'For query %s was found sources: %s',
+        vim.inspect(self.options.query),
+        vim.inspect(sources)
+    )
+    local names_set = {}
+    local names = {}
+    for _, source in pairs(sources) do
+        -- merge similar sources and escape special symbols
+        if not names_set[source.name] then
+            names_set[source.name] = true
+            local escaped_name = string.gsub(source.name, '%%', '%%%%')
+            table.insert(names, escaped_name)
+        end
+    end
+    return table.concat(names, self.options.source_names_separator)
+end
+
+return NullLS

--- a/lua/lualine/components/ex/lsp/single.lua
+++ b/lua/lualine/components/ex/lsp/single.lua
@@ -63,6 +63,9 @@ local function is_lsp_client_active(client)
     if not client then
         return false
     end
+    if client.name == 'null-ls' then
+        return require('null-ls').is_registered({ filetype = vim.bo.filetype })
+    end
     local buffers = vim.lsp.get_buffers_by_client_id(client.id) or {}
     local is_active = vim.tbl_contains(buffers, vim.fn.bufnr('%'))
     return is_active and is_lsp_client_ready(client)

--- a/tests/components/null_ls_spec.lua
+++ b/tests/components/null_ls_spec.lua
@@ -1,0 +1,47 @@
+local null_ls = require('null-ls')
+local l = require('tests.ex.lualine')
+local t = require('tests.ex.busted') --:ignore_all_tests()
+
+local eq = assert.are.equal
+
+local component_name = 'ex.lsp.null_ls'
+describe(component_name, function()
+    null_ls.setup({
+        sources = {
+            null_ls.builtins.completion.spell,
+            null_ls.builtins.formatting.stylua,
+            null_ls.builtins.hover.dictionary,
+            null_ls.builtins.diagnostics.clang_check,
+        },
+    })
+    describe('draw method', function()
+        it('should show the name of any source only once', function()
+            l.test_matched_component(component_name, function(ctbl)
+                local expected = {
+                    clang_check = true,
+                    spell = true,
+                    dictionary = true,
+                    stylua = true,
+                }
+                for name in string.gmatch(ctbl.value, '%w+') do
+                    assert(expected[name], 'Unexpected name ' .. name)
+                    expected[name] = nil
+                end
+            end)
+        end)
+        it('by default should return only sources for the current filetypes or for all', function()
+            vim.bo.filetype = 'lua'
+            l.test_matched_component(component_name, opts, function(ctbl)
+                for name in string.gmatch(ctbl.value, '%w+') do
+                    assert(name ~= 'clang_check', 'Unexpected name ' .. name)
+                end
+            end)
+        end)
+        it('should show names only of sources sutisfied to the query', function()
+            local opts = { query = { method = null_ls.methods.HOVER } }
+            l.test_matched_component(component_name, opts, function(ctbl)
+                eq('dictionary', ctbl.value)
+            end)
+        end)
+    end)
+end)

--- a/tests/ex/busted.lua
+++ b/tests/ex/busted.lua
@@ -20,6 +20,8 @@ function M.it(desc, fun)
     require('plenary.busted').it(desc, fun)
 end
 
+--- Ignores all tests in the default {it}, except those which are in
+--- the require('tests.ex.busted').it
 M.ignore_all_tests = function(self)
     it = function(desc)
         M.ignore_it(desc, nil, 'ignore all')


### PR DESCRIPTION
The new component shows names of the [null-ls](https://github.com/nvimtools/none-ls.nvim) sources according to the specified [`query`](https://github.com/nvimtools/none-ls.nvim/blob/main/doc/SOURCES.md#get_sourcequery).
By default, it shows names of all sources actual to the current buffer. All duplicated names are merged.

```lua
sections = {
  lualine_a = {
    {
      'ex.lsp.null_ls',

      -- The table or function that returns the table with the source query.
      -- By default it shows only actual sorces. To show all registered sources
      -- you can use just empty table:
      -- query = {}
      query = function()
        return { filetype = vim.bo.filetype }
      end,

      -- The string separator between names
      source_names_separator = ',',

      -- The color for the disabled component:
      disabled_color = { fg = 'grey' }

      -- The color for the icon of the disabled component:
      disabled_icon_color = { fg = 'grey' }
    }
  }
}
```

No one source:&nbsp;<img height="18" alt="null-ls-disabled" src="https://github.com/dokwork/lualine-ex/assets/6939832/04ce4a14-a3f9-4d90-a229-d19b78fa7c11">
The `jq` and the `spell` sources are active for the current buffer:<img height="18" alt="nulll-ls-enabled" src="https://github.com/dokwork/lualine-ex/assets/6939832/dda7dbb4-8647-49a2-8c28-8d29a617c2b9">

Closes https://github.com/dokwork/lualine-ex/issues/25
