### PR TITLE
Replace outdated nerd font icon

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,7 +300,7 @@ returns a number:
     -- The configuration of the shorten algorithm.
     shorten = { 
         -- The count of letters, which will be taken from every part of the path
-        lenght = 5, 
+        length = 5,
         -- The list of indexes of filename parts, which should not be shortened
         -- at all (the file name { -1 } is always excluded)
         exclude = nil 

--- a/README.md
+++ b/README.md
@@ -427,7 +427,7 @@ sections = {
         unknown = '?', 
 
         -- Default icon for a case, when no one server is run:
-        lsp_is_off = 'ﮤ',
+        lsp_is_off = '󰚦',
 
         -- Example of the icon for a client, which doesn't have an icon in `nvim-web-devicons`:
         ['null-ls'] = { 'N', color = 'magenta' }

--- a/lua/lualine/components/ex/lsp/single.lua
+++ b/lua/lualine/components/ex/lsp/single.lua
@@ -87,7 +87,7 @@ end
 local Lsp = require('lualine.ex.component'):extend({
     icons = {
         unknown = '?',
-        lsp_is_off = 'ﮤ',
+        lsp_is_off = '󰚦',
     },
     is_enabled = function(component)
         return is_lsp_client_active(component.client)

--- a/lua/lualine/components/ex/relative_filename.lua
+++ b/lua/lualine/components/ex/relative_filename.lua
@@ -3,7 +3,7 @@ local ex = require('lualine.ex')
 local M = require('lualine.ex.component'):extend({
     external_prefix = nil,
     filename_only_prefix = '…/',
-    shorten = { lenght = 5, exclude = nil },
+    shorten = { length = 5, exclude = nil },
     -- -1 - never shorten; 0 - always shorten; >0 - shorten when longer then N symbols
     max_length = 0.3,
 })


### PR DESCRIPTION
With Release v3.0.0 the Material Design Icons were updated and moved to new codepoints (reasons for that are in the release notes). They are still present in the index for reference, but are missing in the actual fonts.

See here: https://www.nerdfonts.com/cheat-sheet