### PR TITLE
Fix tests and ex.git.branch component

### DIFF
--- a/lua/lualine/ex/git_provider.lua
+++ b/lua/lualine/ex/git_provider.lua
@@ -165,6 +165,10 @@ function Git:is_worktree_changed(is_sync)
             end,
             on_stdout = function(err, data)
                 assert(not err, err)
+                -- nil means empty stdout. That case is handled in {on_exit} callback
+                if data == nil then
+                    return
+                end
                 self.__git_status_job.stdout_was_empty = false
                 self.__is_workspace_changed = #data > 0
             end,

--- a/tests/components/lsp_spec.lua
+++ b/tests/components/lsp_spec.lua
@@ -3,13 +3,22 @@ local t = require('tests.ex.busted') --ignore_all_tests()
 local mock = require('luassert.mock')
 local devicons = require('nvim-web-devicons').get_icons()
 
-local eq = assert.are.equal
 local assert_blank = assert.is_blank
 local same = assert.are.same
 
+--- This function transforms the color codes to the lower case strings,
+--- and delegates assertion to the {assert.are.equal}
+local function eq(expected, actual, ...)
+    if type(expected) == 'string' and expected:sub(1, 1) == '#' then
+        expected = expected:lower()
+        actual = actual:lower()
+    end
+    return assert.are.equal(expected, actual, ...)
+end
+
 local lua_lsp = {
     id = 1,
-    name = 'sumneko_lua',
+    name = 'lua_ls',
     config = {
         filetypes = { 'lua' },
     },
@@ -236,7 +245,7 @@ describe('ex.lsp.all component', function()
 
     it('should use colors from the `icons` or devicons', function()
         -- given:
-        local lua_color = lua_icon.color
+        local lua_color = lua_icon.color:lower()
         local vim_color = '#7cfc00'
         local all_lsp = l.init_component(
             component_name,
@@ -249,9 +258,9 @@ describe('ex.lsp.all component', function()
         local rc = l.render_component(all_lsp)
         -- then:
         local hls = get_all_highlights(rc)
-        assert(#hls > 2, 'Colors not enough in ' .. rc)
+        assert(#hls > 2, 'Not enough colors in ' .. rc)
         for _, hl in ipairs(hls) do
-            local fg = l.get_gui_color(hl, 'fg')
+            local fg = l.get_gui_color(hl, 'fg'):lower()
             assert(
                 vim_color == fg or lua_color == fg,
                 string.format('Unexpected fg color %s in %s of the component %s', fg, hl, rc)

--- a/tests/components/relative_filename_spec.lua
+++ b/tests/components/relative_filename_spec.lua
@@ -1,4 +1,5 @@
 local l = require('tests.ex.lualine')
+local t = require('tests.ex.busted') --:ignore_all_tests()
 
 local mock = { o = {}, api = {} }
 local eq = assert.are.equal
@@ -81,7 +82,7 @@ describe('relative_filename component', function()
         end)
 
         it('should always shorten the path when {max_length} is 0', function()
-            local opts = { max_length = 0 }
+            local opts = { max_length = 0, shorten = { length = 1 } }
             l.test_matched_component(component_name, opts, function(ct)
                 eq('a/x/test.txt', ct.value)
             end)
@@ -101,8 +102,10 @@ describe('relative_filename component', function()
                 local opts = {
                     max_length = function(path)
                         passed_arg = path
+                        -- 0 means that every part of the path should be shorten
                         return 0
                     end,
+                    shorten = { length = 1 },
                 }
                 l.test_matched_component(component_name, opts, function(ct)
                     eq('a/x/test.txt', ct.value)

--- a/tests/ex/git.lua
+++ b/tests/ex/git.lua
@@ -30,7 +30,9 @@ function Git:git(...)
     local cmd = table.concat({ ... }, ' ')
     cmd = string.format('git -C %s %s %s', self.git_root, cmd, dev_null)
     log.debug('Execute: ' .. cmd)
-    os.execute(cmd)
+    if not os.execute(cmd) then
+        error('Error on execute ' .. cmd)
+    end
 end
 
 function Git:init(branch)

--- a/tests/git_provider_spec.lua
+++ b/tests/git_provider_spec.lua
@@ -1,6 +1,6 @@
-local t = require('tests.ex.busted')
 local fs = require('tests.ex.fs')
 local Git = require('tests.ex.git')
+local t = require('tests.ex.busted') --:ignore_all_tests()
 
 local eq = assert.are.equal
 


### PR DESCRIPTION
- The ex.git.branch component was broken after the change in plenary: https://github.com/nvim-lua/plenary.nvim/commit/3707cdb1e43f5cea73afb6037e6494e7ce847a66
- The tests for relative_filename were broken after fix typo in https://github.com/dokwork/lualine-ex/commit/6f062b3638c9a3f62b03f0bf9e1bf0219ce05808
- The tests for lsp were broken because of 'nvim-web-devicons' has colors in upper case now 